### PR TITLE
Update to released API's NeoForgeExtension.setVersion()

### DIFF
--- a/src/main/java/com/almostreliable/almostgradle/AlmostGradleExtension.java
+++ b/src/main/java/com/almostreliable/almostgradle/AlmostGradleExtension.java
@@ -186,7 +186,7 @@ public abstract class AlmostGradleExtension {
     private void applyBasicMod() {
         var neoForge = project.getExtensions().getByType(NeoForgeExtension.class);
         var javaPlugin = project.getExtensions().getByType(JavaPluginExtension.class);
-        neoForge.getVersion().set(getNeoforgeVersion());
+        neoForge.setVersion(getNeoforgeVersion());
         var mainMod = neoForge.getMods().maybeCreate(getModId());
         var mainSourceSet = javaPlugin.getSourceSets().getByName("main");
 


### PR DESCRIPTION
## Proposed Changes
Fix build against now-stabilized ModDevGradle API.

## Additional Context
I encountered a runtime error while setting up a AlmostReliable/merequester dev environment:

```
* Where:
Build file 'C:\xxx\merequester\build.gradle.kts' line: 6

* What went wrong:
'org.gradle.api.provider.Property net.neoforged.moddevgradle.dsl.NeoForgeExtension.getVersion()'
```

While trying to run the almostgradle `test` task, the 2.0.80 version of moddevgradle caused a compilation error:

```
C:\xxx\almostgradle\src\main\java\com\almostreliable\almostgradle\AlmostGradleExtension.java:189: error: cannot find symbol
        neoForge.getVersion().set(getNeoforgeVersion());
                             ^
  symbol:   method set(String)
  location: class String
1 error
```

The API changed in neoforged/ModDevGradle#200 which became 2.0.64-beta.