### PR TITLE
recipe viewer run config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to [Semantic Versioning].
 
 ## Unreleased
-- /
+
+- added option for disable loading the test mod in recipe viewer run configs
+- fixed recipe viewer run configs not loading the test source set and not executing compile tasks
 
 ## [1.2.0] - 2025-04-17
 

--- a/README.md
+++ b/README.md
@@ -336,12 +336,14 @@ Possible values are:
 - `full` - load the full mod into the compile time classpath
 - `none` - don't load anything into the compile time classpath
 
-*Run Config* refers to whether a run configuration should be created for the recipe viewer.
+*Run Config* refers to whether a run configuration should be created for the recipe viewer. If *Run Config* is enabled,
+the option *Test Mod* defines whether the test mod should be loaded in that run configuration.
 
 ### Defaults:
 
 Mode: `none`<br>
 Run Config: `false`<br>
+Test Mod: `true`<br>
 Minecraft Version: same as project<br>
 Maven Repository: default for the respective recipe viewer
 
@@ -365,6 +367,7 @@ almostgradle.setup {
             runConfig = true
             mode = LoadingMode.FULL
             version = "x.x.x"
+            testMod = false
         }
         jei {
             runConfig = false
@@ -391,6 +394,7 @@ almostgradle.recipeViewers.emi.maven = https://modmaven.dev
 almostgradle.recipeViewers.rei.runConfig = true
 almostgradle.recipeViewers.rei.mode = FULL
 almostgradle.recipeViewers.rei.version = x.x.x
+almostgradle.recipeViewers.rei.testMod = false
 
 almostgradle.recipeViewers.jei.runConfig = true
 almostgradle.recipeViewers.jei.mode = API

--- a/src/main/java/com/almostreliable/almostgradle/AlmostGradleExtension.java
+++ b/src/main/java/com/almostreliable/almostgradle/AlmostGradleExtension.java
@@ -120,7 +120,7 @@ public abstract class AlmostGradleExtension {
         applyApiSourceSet();
         applyBasicMod();
         applyTestMod();
-        getRecipeViewers().createRuns();
+        getRecipeViewers().createRuns(getModId());
         onPostRunConfigs();
     }
 

--- a/src/main/java/com/almostreliable/almostgradle/AlmostGradleExtension.java
+++ b/src/main/java/com/almostreliable/almostgradle/AlmostGradleExtension.java
@@ -120,7 +120,7 @@ public abstract class AlmostGradleExtension {
         applyApiSourceSet();
         applyBasicMod();
         applyTestMod();
-        getRecipeViewers().createRuns(getModId());
+        getRecipeViewers().createRuns();
         onPostRunConfigs();
     }
 

--- a/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewerOptions.java
+++ b/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewerOptions.java
@@ -35,6 +35,10 @@ public abstract class RecipeViewerOptions {
                 .map(s -> s.equals("true"))
                 .orElse(false));
         getMinecraftVersion().convention(providers.gradleProperty(propPrefix + ".minecraftVersion"));
+        getTestMod().convention(providers
+                .gradleProperty(propPrefix + ".testMod")
+                .map(s -> s.equals("true"))
+                .orElse(true));
     }
 
     public abstract Property<String> getMavenRepository();
@@ -46,6 +50,8 @@ public abstract class RecipeViewerOptions {
     public abstract Property<Boolean> getRunConfig();
 
     public abstract Property<String> getMinecraftVersion();
+
+    public abstract Property<Boolean> getTestMod();
 
     public Provider<ModuleDependency> getDependency() {
         var almostGradle = project.getExtensions().getByType(AlmostGradleExtension.class);

--- a/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewers.java
+++ b/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewers.java
@@ -11,6 +11,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 
 import javax.inject.Inject;
+import java.util.Set;
 
 public abstract class RecipeViewers {
 
@@ -56,13 +57,13 @@ public abstract class RecipeViewers {
     }
 
     @Internal
-    public void createRuns() {
-        createRun(emi, ModDependency.EMI);
-        createRun(jei, ModDependency.JEI);
-        createRun(rei, ModDependency.REI);
+    public void createRuns(String mainModId) {
+        createRun(mainModId, emi, ModDependency.EMI);
+        createRun(mainModId, jei, ModDependency.JEI);
+        createRun(mainModId, rei, ModDependency.REI);
     }
 
-    private void createRun(RecipeViewerOptions settings, ModDependency mod) {
+    private void createRun(String mainModId, RecipeViewerOptions settings, ModDependency mod) {
         if (!settings.getVersion().isPresent()) {
             return;
         }
@@ -86,20 +87,28 @@ public abstract class RecipeViewers {
 
         var neoForge = this.project.getExtensions().getByType(NeoForgeExtension.class);
         var java = this.project.getExtensions().getByType(JavaPluginExtension.class);
+        var mainMod = neoForge.getMods().maybeCreate(mainModId);
+        var testMod = neoForge.getMods().maybeCreate("test");
         var mainSourceSet = java.getSourceSets().getByName("main");
+        var testSourceSet = java.getSourceSets().getByName("test");
 
         var dep = settings.getDependency();
         var apiDep = settings.getApiDependency();
 
         if (settings.getRunConfig().isPresent() && settings.getRunConfig().get()) {
             var sourceSet = java.getSourceSets().create(mod.id() + "Run");
-            sourceSet.setCompileClasspath(sourceSet.getCompileClasspath().plus(mainSourceSet.getCompileClasspath()));
-            sourceSet.setRuntimeClasspath(sourceSet.getRuntimeClasspath().plus(mainSourceSet.getRuntimeClasspath()));
+            sourceSet.setCompileClasspath(sourceSet.getCompileClasspath()
+                    .plus(mainSourceSet.getCompileClasspath())
+                    .plus(testSourceSet.getCompileClasspath()));
+            sourceSet.setRuntimeClasspath(sourceSet.getRuntimeClasspath()
+                    .plus(mainSourceSet.getRuntimeClasspath())
+                    .plus(testSourceSet.getRuntimeClasspath()));
 
             neoForge.getRuns().create(sourceSet.getName(), (run) -> {
                 run.getIdeName().set("RecipeViewer (" + mod.id().toUpperCase() + ")");
                 run.client();
                 run.getSourceSet().set(sourceSet);
+                run.getLoadedMods().set(Set.of(mainMod, testMod)); // set loaded mods to avoid confusion
             });
 
             var config = Utils.createLocalRuntime(project,

--- a/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewers.java
+++ b/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewers.java
@@ -1,6 +1,7 @@
 package com.almostreliable.almostgradle.dependency;
 
 import com.almostreliable.almostgradle.Utils;
+import net.neoforged.moddevgradle.dsl.ModModel;
 import net.neoforged.moddevgradle.dsl.NeoForgeExtension;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -11,6 +12,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 
 import javax.inject.Inject;
+import java.util.HashSet;
 import java.util.Set;
 
 public abstract class RecipeViewers {
@@ -74,6 +76,7 @@ public abstract class RecipeViewers {
         Utils.log(project, "\t* Version", settings.getVersion().get());
         Utils.log(project, "\t* Mode", settings.getMode().get().toString());
         Utils.log(project, "\t* Run Config Enabled", settings.getRunConfig().get());
+        Utils.log(project, "\t* Test Mod Enabled", settings.getTestMod().get());
         Utils.log(project, "\t* Minecraft Version", settings.getMinecraftVersion().orElse("NOT_DEFINED").get());
         Utils.log(project, "\t* Repository", settings.getMavenRepository().get());
 
@@ -97,18 +100,29 @@ public abstract class RecipeViewers {
 
         if (settings.getRunConfig().isPresent() && settings.getRunConfig().get()) {
             var sourceSet = java.getSourceSets().create(mod.id() + "Run");
-            sourceSet.setCompileClasspath(sourceSet.getCompileClasspath()
-                    .plus(mainSourceSet.getCompileClasspath())
-                    .plus(testSourceSet.getCompileClasspath()));
-            sourceSet.setRuntimeClasspath(sourceSet.getRuntimeClasspath()
-                    .plus(mainSourceSet.getRuntimeClasspath())
-                    .plus(testSourceSet.getRuntimeClasspath()));
+
+            var compileClasspath = sourceSet.getCompileClasspath()
+                    .plus(mainSourceSet.getCompileClasspath());
+            var runtimeClasspath = sourceSet.getRuntimeClasspath()
+                    .plus(mainSourceSet.getRuntimeClasspath());
+
+            Set<ModModel> loadedMods = new HashSet<>();
+            loadedMods.add(mainMod);
+
+            if (settings.getTestMod().get()) {
+                compileClasspath = compileClasspath.plus(testSourceSet.getCompileClasspath());
+                runtimeClasspath = runtimeClasspath.plus(testSourceSet.getRuntimeClasspath());
+                loadedMods.add(testMod);
+            }
+
+            sourceSet.setCompileClasspath(compileClasspath);
+            sourceSet.setRuntimeClasspath(runtimeClasspath);
 
             neoForge.getRuns().create(sourceSet.getName(), (run) -> {
                 run.getIdeName().set("RecipeViewer (" + mod.id().toUpperCase() + ")");
                 run.client();
                 run.getSourceSet().set(sourceSet);
-                run.getLoadedMods().set(Set.of(mainMod, testMod)); // set loaded mods to avoid confusion
+                run.getLoadedMods().set(loadedMods);
             });
 
             var config = Utils.createLocalRuntime(project,

--- a/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewers.java
+++ b/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewers.java
@@ -1,5 +1,6 @@
 package com.almostreliable.almostgradle.dependency;
 
+import com.almostreliable.almostgradle.AlmostGradleExtension;
 import com.almostreliable.almostgradle.Utils;
 import net.neoforged.moddevgradle.dsl.ModModel;
 import net.neoforged.moddevgradle.dsl.NeoForgeExtension;
@@ -59,13 +60,13 @@ public abstract class RecipeViewers {
     }
 
     @Internal
-    public void createRuns(String mainModId) {
-        createRun(mainModId, emi, ModDependency.EMI);
-        createRun(mainModId, jei, ModDependency.JEI);
-        createRun(mainModId, rei, ModDependency.REI);
+    public void createRuns() {
+        createRun(emi, ModDependency.EMI);
+        createRun(jei, ModDependency.JEI);
+        createRun(rei, ModDependency.REI);
     }
 
-    private void createRun(String mainModId, RecipeViewerOptions settings, ModDependency mod) {
+    private void createRun(RecipeViewerOptions settings, ModDependency mod) {
         if (!settings.getVersion().isPresent()) {
             return;
         }
@@ -90,10 +91,9 @@ public abstract class RecipeViewers {
 
         var neoForge = this.project.getExtensions().getByType(NeoForgeExtension.class);
         var java = this.project.getExtensions().getByType(JavaPluginExtension.class);
-        var mainMod = neoForge.getMods().maybeCreate(mainModId);
-        var testMod = neoForge.getMods().maybeCreate("test");
+        var almostGradle = this.project.getExtensions().getByType(AlmostGradleExtension.class);
+        var mainMod = neoForge.getMods().maybeCreate(almostGradle.getModId());
         var mainSourceSet = java.getSourceSets().getByName("main");
-        var testSourceSet = java.getSourceSets().getByName("test");
 
         var dep = settings.getDependency();
         var apiDep = settings.getApiDependency();
@@ -109,7 +109,10 @@ public abstract class RecipeViewers {
             Set<ModModel> loadedMods = new HashSet<>();
             loadedMods.add(mainMod);
 
-            if (settings.getTestMod().get()) {
+            if (almostGradle.getTestMod().get() && settings.getTestMod().get()) {
+                var testMod = neoForge.getMods().maybeCreate(AlmostGradleExtension.TESTMOD_ID);
+                var testSourceSet = java.getSourceSets().getByName("test");
+
                 compileClasspath = compileClasspath.plus(testSourceSet.getCompileClasspath());
                 runtimeClasspath = runtimeClasspath.plus(testSourceSet.getRuntimeClasspath());
                 loadedMods.add(testMod);


### PR DESCRIPTION
## Proposed Changes
- fixed recipe viewer run configs not loading the test source set
  - this resulted in recipe viewer run configs now running the test tasks such as `testClasses` to compile test sources
- added a configuration option to disable loading the test mod in the recipe viewer run configs
- added documentation to the readme how to use the new option
