### PR TITLE
Recipe Viewer adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,9 @@ dependency {
 }
 ```
 
+If you depend on a recipe viewer at compile time and need a version range, the specified recipe viewer version can be
+accessed via the `<viewer>Version` property. For example `versionRange = "[${jeiVersion},)"`.
+
 # Configurations
 
 Next to the default ones, the plugin offers additional configurations to load dependencies into the classpath.

--- a/src/main/java/com/almostreliable/almostgradle/AlmostGradleExtension.java
+++ b/src/main/java/com/almostreliable/almostgradle/AlmostGradleExtension.java
@@ -129,7 +129,7 @@ public abstract class AlmostGradleExtension {
             project
                     .getTasks()
                     .named("processResources", ProcessResources.class)
-                    .configure(new ProcessResourceHandler(project));
+                    .configure(new ProcessResourceHandler(project, getRecipeViewers()));
         }
     }
 

--- a/src/main/java/com/almostreliable/almostgradle/ProcessResourceHandler.java
+++ b/src/main/java/com/almostreliable/almostgradle/ProcessResourceHandler.java
@@ -1,5 +1,7 @@
 package com.almostreliable.almostgradle;
 
+import com.almostreliable.almostgradle.dependency.RecipeViewerOptions;
+import com.almostreliable.almostgradle.dependency.RecipeViewers;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -9,6 +11,8 @@ import org.gradle.language.jvm.tasks.ProcessResources;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.*;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.StreamSupport;
@@ -17,13 +21,20 @@ public class ProcessResourceHandler implements Action<ProcessResources> {
 
     public static final String USER_KEY = "githubUser";
     public static final String REPO_KEY = "githubRepo";
+    public static final Map<String, Function<RecipeViewers, RecipeViewerOptions>> RECIPE_VIEWER_VERSIONS = Map.of(
+            "jeiVersion", RecipeViewers::getJei,
+            "emiVersion", RecipeViewers::getEmi,
+            "reiVersion", RecipeViewers::getRei
+    );
 
     private final List<String> targets = List.of("META-INF/neoforge.mods.toml", "pack.mcmeta");
 
     private final Project project;
+    private final RecipeViewers recipeViewers;
 
-    public ProcessResourceHandler(Project project) {
+    public ProcessResourceHandler(Project project, RecipeViewers recipeViewers) {
         this.project = project;
+        this.recipeViewers = recipeViewers;
     }
 
     @Override
@@ -92,9 +103,34 @@ public class ProcessResourceHandler implements Action<ProcessResources> {
                         "\t* Property '" + USER_KEY + "' found in target but not set, defaulting to 'AlmostReliable'");
                 return Optional.of("AlmostReliable");
             }
+
+            for (var entry : RECIPE_VIEWER_VERSIONS.entrySet()) {
+                var viewerVersion = getRecipeViewerVersion(
+                        key,
+                        entry.getKey(),
+                        () -> entry.getValue().apply(recipeViewers)
+                );
+                if (viewerVersion.isPresent()) {
+                    return viewerVersion;
+                }
+            }
         }
 
         return Optional.ofNullable(property).map(Object::toString);
+    }
+
+    private Optional<String> getRecipeViewerVersion(String key, String viewerKey, Supplier<RecipeViewerOptions> recipeViewerOptions) {
+        if (key.equals(viewerKey)) {
+            var version = recipeViewerOptions.get().getVersion();
+            if (version.isPresent()) {
+                return Optional.of(version.get());
+            }
+
+            var logger = project.getLogger();
+            logger.lifecycle("\t* Property '" + viewerKey + "' found in target but the recipe viewer is not enabled");
+        }
+
+        return Optional.empty();
     }
 
     private Map<String, String> createProperties(Collection<String> keys) {

--- a/src/main/java/com/almostreliable/almostgradle/dependency/ModDependency.java
+++ b/src/main/java/com/almostreliable/almostgradle/dependency/ModDependency.java
@@ -1,7 +1,9 @@
 package com.almostreliable.almostgradle.dependency;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.dsl.DependencyFactory;
+
+import java.util.List;
 
 @SuppressWarnings("UnstableApiUsage")
 public interface ModDependency {
@@ -13,9 +15,9 @@ public interface ModDependency {
 
     String defaultMavenRepo();
 
-    ModuleDependency createApiDependency(String minecraftVersion, String depVersion, DependencyFactory factory);
+    Iterable<Dependency> createApiDependencies(String minecraftVersion, String depVersion, DependencyFactory factory);
 
-    ModuleDependency createDependency(String minecraftVersion, String depVersion, DependencyFactory factory);
+    Iterable<Dependency> createDependencies(String minecraftVersion, String depVersion, DependencyFactory factory);
 
     class Emi implements ModDependency {
         @Override
@@ -29,13 +31,17 @@ public interface ModDependency {
         }
 
         @Override
-        public ModuleDependency createApiDependency(String minecraftVersion, String depVersion, DependencyFactory factory) {
-            return factory.create("dev.emi", "emi-neoforge", depVersion + "+" + minecraftVersion, "api", null);
+        public Iterable<Dependency> createApiDependencies(String minecraftVersion, String depVersion, DependencyFactory factory) {
+            return List.of(
+                    factory.create("dev.emi", "emi-neoforge", depVersion + "+" + minecraftVersion, "api", null)
+            );
         }
 
         @Override
-        public ModuleDependency createDependency(String minecraftVersion, String depVersion, DependencyFactory factory) {
-            return factory.create("dev.emi", "emi-neoforge", depVersion + "+" + minecraftVersion);
+        public Iterable<Dependency> createDependencies(String minecraftVersion, String depVersion, DependencyFactory factory) {
+            return List.of(
+                    factory.create("dev.emi", "emi-neoforge", depVersion + "+" + minecraftVersion)
+            );
         }
     }
 
@@ -51,13 +57,17 @@ public interface ModDependency {
         }
 
         @Override
-        public ModuleDependency createApiDependency(String minecraftVersion, String depVersion, DependencyFactory factory) {
-            return factory.create("me.shedaniel", "RoughlyEnoughItems-api-neoforge", depVersion);
+        public Iterable<Dependency> createApiDependencies(String minecraftVersion, String depVersion, DependencyFactory factory) {
+            return List.of(
+                    factory.create("me.shedaniel", "RoughlyEnoughItems-api-neoforge", depVersion)
+            );
         }
 
         @Override
-        public ModuleDependency createDependency(String minecraftVersion, String depVersion, DependencyFactory factory) {
-            return factory.create("me.shedaniel", "RoughlyEnoughItems-neoforge", depVersion);
+        public Iterable<Dependency> createDependencies(String minecraftVersion, String depVersion, DependencyFactory factory) {
+            return List.of(
+                    factory.create("me.shedaniel", "RoughlyEnoughItems-neoforge", depVersion)
+            );
         }
     }
 
@@ -73,15 +83,18 @@ public interface ModDependency {
         }
 
         @Override
-        public ModuleDependency createApiDependency(String minecraftVersion, String depVersion, DependencyFactory factory) {
-            return factory
-                    .create("mezz.jei", "jei-" + minecraftVersion + "-neoforge-api", depVersion)
-                    .setTransitive(false);
+        public Iterable<Dependency> createApiDependencies(String minecraftVersion, String depVersion, DependencyFactory factory) {
+            return List.of(
+                    factory.create("mezz.jei", "jei-" + minecraftVersion + "-neoforge-api", depVersion)
+                            .setTransitive(false)
+            );
         }
 
         @Override
-        public ModuleDependency createDependency(String minecraftVersion, String depVersion, DependencyFactory factory) {
-            return factory.create("mezz.jei", "jei-" + minecraftVersion + "-neoforge", depVersion).setTransitive(false);
+        public Iterable<Dependency> createDependencies(String minecraftVersion, String depVersion, DependencyFactory factory) {
+            return List.of(
+                    factory.create("mezz.jei", "jei-" + minecraftVersion + "-neoforge", depVersion).setTransitive(false)
+            );
         }
     }
 }

--- a/src/main/java/com/almostreliable/almostgradle/dependency/ModDependency.java
+++ b/src/main/java/com/almostreliable/almostgradle/dependency/ModDependency.java
@@ -86,6 +86,8 @@ public interface ModDependency {
         public Iterable<Dependency> createApiDependencies(String minecraftVersion, String depVersion, DependencyFactory factory) {
             return List.of(
                     factory.create("mezz.jei", "jei-" + minecraftVersion + "-neoforge-api", depVersion)
+                            .setTransitive(false),
+                    factory.create("mezz.jei", "jei-" + minecraftVersion + "-common-api", depVersion)
                             .setTransitive(false)
             );
         }

--- a/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewerOptions.java
+++ b/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewerOptions.java
@@ -3,7 +3,7 @@ package com.almostreliable.almostgradle.dependency;
 
 import com.almostreliable.almostgradle.AlmostGradleExtension;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -53,15 +53,15 @@ public abstract class RecipeViewerOptions {
 
     public abstract Property<Boolean> getTestMod();
 
-    public Provider<ModuleDependency> getDependency() {
+    public Provider<Iterable<Dependency>> getDependencies() {
         var almostGradle = project.getExtensions().getByType(AlmostGradleExtension.class);
         var mcv = getMinecraftVersion().orElse(almostGradle.getMinecraftVersion()).get();
-        return getVersion().map(v -> mod.createDependency(mcv, v, project.getDependencyFactory()));
+        return getVersion().map(v -> mod.createDependencies(mcv, v, project.getDependencyFactory()));
     }
 
-    public Provider<ModuleDependency> getApiDependency() {
+    public Provider<Iterable<Dependency>> getApiDependencies() {
         var almostGradle = project.getExtensions().getByType(AlmostGradleExtension.class);
         var mcv = getMinecraftVersion().orElse(almostGradle.getMinecraftVersion()).get();
-        return getVersion().map(v -> mod.createApiDependency(mcv, v, project.getDependencyFactory()));
+        return getVersion().map(v -> mod.createApiDependencies(mcv, v, project.getDependencyFactory()));
     }
 }

--- a/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewers.java
+++ b/src/main/java/com/almostreliable/almostgradle/dependency/RecipeViewers.java
@@ -95,8 +95,8 @@ public abstract class RecipeViewers {
         var mainMod = neoForge.getMods().maybeCreate(almostGradle.getModId());
         var mainSourceSet = java.getSourceSets().getByName("main");
 
-        var dep = settings.getDependency();
-        var apiDep = settings.getApiDependency();
+        var deps = settings.getDependencies();
+        var apiDeps = settings.getApiDependencies();
 
         if (settings.getRunConfig().isPresent() && settings.getRunConfig().get()) {
             var sourceSet = java.getSourceSets().create(mod.id() + "Run");
@@ -131,7 +131,7 @@ public abstract class RecipeViewers {
             var config = Utils.createLocalRuntime(project,
                     sourceSet.getRuntimeClasspathConfigurationName(),
                     mod.id());
-            config.withDependencies(d -> d.addLater(dep));
+            config.withDependencies(d -> d.addAllLater(deps));
         }
 
         var runtimeOnly = project.getConfigurations().getByName("localRuntime");
@@ -141,10 +141,10 @@ public abstract class RecipeViewers {
 
         switch (settings.getMode().get()) {
             case API -> {
-                compileOnly.withDependencies(d -> d.addLater(apiDep));
+                compileOnly.withDependencies(d -> d.addAllLater(apiDeps));
             }
             case FULL -> {
-                compileOnly.withDependencies(d -> d.addLater(dep));
+                compileOnly.withDependencies(d -> d.addAllLater(deps));
             }
         }
     }


### PR DESCRIPTION
This pull request introduces two main changes.

1. The recipe viewers can now define multiple dependency artifacts. Since JEI requires the common as well as the NeoForge API to work properly when using the `Mode.API`, this change was necessary to load both artifacts. The remaining recipe viewers currently only rely on one artifact.
2. The `gradle.properties` property replacement system now handles properties like `jeiVersion` implicitly. If you depend on a recipe viewer and want to specify a version range in the `mods.toml`, you can now use these implicit properties. The new system checks if the recipe viewer is enabled and doesn't complain about a missing property anymore.

The readme was updated accordingly.